### PR TITLE
Add VersionEye Badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Lstr/Silex
 
+[![Dependency Status](https://www.versioneye.com/user/projects/532e6d03f599491449000238/badge.svg?style=flat)](https://www.versioneye.com/user/projects/532e6d03f599491449000238)
+
 Provides:
 
  - lstr-silex-app


### PR DESCRIPTION
The lstr-silex badge is on the upcrypto project. While removing it from
there, I am adding it here.
